### PR TITLE
Prevent infinite loop when only BOT_PREFIX passed

### DIFF
--- a/errbot/core.py
+++ b/errbot/core.py
@@ -350,7 +350,7 @@ class ErrBot(Backend, StoreMixin):
                         args = " ".join(text_split[i:])
                     else:
                         i -= 1
-                if i == 0:
+                if i <= 0:
                     break
 
             if (


### PR DESCRIPTION
Handle the case where the only content of a message was the bot prefix. This breaks out of an otherwise infinite loop